### PR TITLE
FIx spelling of KoaRecevier in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ For instance, if you go with Prisma, your Bolt app code will look like the one b
 import Router from '@koa/router';
 import Koa from 'koa';
 import { App, FileInstallationStore, LogLevel } from '@slack/bolt';
-import { KoaRecevier } from '@seratch_/bolt-koa';
+import { KoaReceiver } from '@seratch_/bolt-koa';
 
 const koa = new Koa();
 const router = new Router();
 
-const receiver = new KoaRecevier({
+const receiver = new KoaReceiver({
   signingSecret: process.env.SLACK_SIGNING_SECRET!,
   clientId: process.env.SLACK_CLIENT_ID,
   clientSecret: process.env.SLACK_CLIENT_SECRET,

--- a/packages/bolt-koa/README.md
+++ b/packages/bolt-koa/README.md
@@ -85,12 +85,12 @@ import Router from '@koa/router';
 import Koa from 'koa';
 import { App, FileInstallationStore, LogLevel } from '@slack/bolt';
 import { FileStateStore } from '@slack/oauth';
-import { KoaRecevier } from '@seratch_/bolt-koa';
+import { KoaReceiver } from '@seratch_/bolt-koa';
 
 const koa = new Koa();
 const router = new Router();
 
-const receiver = new KoaRecevier({
+const receiver = new KoaReceiver({
   signingSecret: process.env.SLACK_SIGNING_SECRET!,
   clientId: process.env.SLACK_CLIENT_ID,
   clientSecret: process.env.SLACK_CLIENT_SECRET,

--- a/packages/bolt-koa/src/tests/bolt-example.ts
+++ b/packages/bolt-koa/src/tests/bolt-example.ts
@@ -2,12 +2,12 @@ import Router from '@koa/router';
 import Koa from 'koa';
 import { App, FileInstallationStore, LogLevel } from '@slack/bolt';
 import { FileStateStore } from '@slack/oauth';
-import KoaRecevier from '../receivers/KoaReceiver';
+import KoaReceiver from '../receivers/KoaReceiver';
 
 const koa = new Koa();
 const router = new Router();
 
-const receiver = new KoaRecevier({
+const receiver = new KoaReceiver({
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   signingSecret: process.env.SLACK_SIGNING_SECRET!,
   clientId: process.env.SLACK_CLIENT_ID,


### PR DESCRIPTION
This fIxes the spelling of `KoaRecevier` in examples.